### PR TITLE
Remove redundant flowsheets entry points now defined in watertap package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
         working-directory: backend
         env:
           PYTHONPATH: ${{ env.GITHUB_WORKSPACE }}/backend
-        run: pytest tests
+        run: pytest tests -v
 
       - name: run backend server
         run: uvicorn --app-dir backend/app main:app --reload --host 0.0.0.0 --port 8001 & sleep 30

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,10 @@ jobs:
         run: |
           pip install --progress-bar off .
 
+      - name: Display installed environment
+        run: |
+          conda env export --no-builds
+
       - name: run pytest
         working-directory: backend
         env:

--- a/backend/tests/app/routers/test_flowsheets.py
+++ b/backend/tests/app/routers/test_flowsheets.py
@@ -22,10 +22,16 @@ def client():
     return TestClient(app)
 
 
-@pytest.fixture(scope="module")
-def flowsheet_id():
-    mgr = fm.FlowsheetManager()
-    return list(mgr._flowsheets.keys())[0]
+def pytest_generate_tests(metafunc):
+    if "flowsheet_id" in metafunc.fixturenames:
+        from watertap.ui.fsapi import FlowsheetInterface
+
+        module_names = list(FlowsheetInterface.from_installed_packages())
+        metafunc.parametrize(
+            "flowsheet_id",
+            list(module_names),
+            scope="module",
+        )
 
 
 def get_flowsheet(client, flowsheet_id, r, get_body=True, query_params=None):

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,6 @@ setup(
 
     entry_points={
         "watertap.flowsheets": [
-            "metab = watertap.examples.flowsheets.case_studies.wastewater_resource_recovery.metab.metab_ui",
-            "RO = watertap.examples.flowsheets.case_studies.seawater_RO_desalination.seawater_RO_desalination",
         ],
     }
 )


### PR DESCRIPTION
- Apply minimal changes to this repo to ensure compatibility with changes introduced in watertap-org/watertap#761
- There is still duplicated code left in `backend/app/internal/flowsheet_manager.py` that could be removed as it now lives in `watertap.ui.fsapi.FlowsheetInterface`, but unless it's absolutely necessary, I'd prefer to leave it as-is until after the first upcoming RC