### PR TITLE
Fix log component bug

### DIFF
--- a/backend/app/routers/flowsheets.py
+++ b/backend/app/routers/flowsheets.py
@@ -499,7 +499,7 @@ async def remove_flowsheet(request: Request):
 
     return {"new_value": new_value}
 @router.get("/get_logs")
-async def get_logs() -> List[str]:
+async def get_logs() -> List:
     """Get backend logs.
 
     Returns:


### PR DESCRIPTION
With the pydantic version update, a bug was introduced into the get_logs api endpoint function.
fix: make return type for logs a list of any kind