### PR TITLE
Track changes in `watertap` before v1.0

### DIFF
--- a/backend/app/internal/parameter_sweep.py
+++ b/backend/app/internal/parameter_sweep.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from fastapi import HTTPException
 import numpy as np
 from watertap.tools.parameter_sweep import LinearSample, ParameterSweep, parameter_sweep
-import watertap.examples.flowsheets.case_studies.wastewater_resource_recovery.amo_1575_magprex.magprex as magprex
 from importlib import import_module
 import idaes.logger as idaeslog
 from pyomo.environ import (

--- a/backend/tests/app/routers/test_flowsheets.py
+++ b/backend/tests/app/routers/test_flowsheets.py
@@ -82,7 +82,7 @@ def test_get_all(client):
     data = body["flowsheet_list"]
     for item in data:
         # validates the result object, too
-        info = fm.FlowsheetInfo.parse_obj(item)
+        info = fm.FlowsheetInfo.model_validate(item)
         assert info.name != ""
 
 
@@ -93,7 +93,7 @@ def test_get_config(client, flowsheet_id):
     assert response.status_code == 200, body
     # make sure it's a non-empty valid response
     assert body != {}
-    fs_exp = FlowsheetExport.parse_obj(body)
+    fs_exp = FlowsheetExport.model_validate(body)
     assert fs_exp.name != ""
 
     # this time build the model, make sure there is content


### PR DESCRIPTION
- [x] Replace deprecated Pydantic method parse_obj() (related to watertap-org/watertap#1459)
- [x] Replace `watertap.examples.flowsheets` imports to `watertap.flowsheets` (watertap-org/watertap#1438)
- [x] Replace `watertap.tools.parameter_sweep` imports to `parameter_sweep` (needs watertap-org/watertap#1437)