### PR TITLE
Terminate workflow processes after completing tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,11 +90,39 @@ jobs:
 
       - name: stop windows frontend service
         if: runner.os == 'Windows'
-        run: for /f "tokens=5" %a in ('netstat -aon ^| findstr :3000') do taskkill /PID %a /F
+        run: |
+            $port = 3000
+            $netTCPConnection = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
+            if ($netTCPConnection) {
+            $process = Get-Process -Id $netTCPConnection.OwningProcess -ErrorAction SilentlyContinue
+            if ($process) {
+                Stop-Process -Id $process.Id -Force
+                Write-Host "Process on port $port killed."
+            } else {
+                Write-Host "No process found using port $port."
+            }
+            } else {
+            Write-Host "No TCP connection found on port $port."
+            }
+        shell: pwsh
 
       - name: stop windows backend service
         if: runner.os == 'Windows'
-        run: for /f "tokens=5" %a in ('netstat -aon ^| findstr :8001') do taskkill /PID %a /F
+        run: |
+            $port = 8001
+            $netTCPConnection = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
+            if ($netTCPConnection) {
+            $process = Get-Process -Id $netTCPConnection.OwningProcess -ErrorAction SilentlyContinue
+            if ($process) {
+                Stop-Process -Id $process.Id -Force
+                Write-Host "Process on port $port killed."
+            } else {
+                Write-Host "No process found using port $port."
+            }
+            } else {
+            Write-Host "No TCP connection found on port $port."
+            }
+        shell: pwsh
 
       - name: Upload artifact for screenshots & videos
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,10 +81,10 @@ jobs:
         run: npx cypress run
 
       - name: stop frontend service
-        run: sudo fuser -k 3000/tcp
+        run: fuser -k 3000/tcp
 
       - name: stop backend service
-        run: sudo fuser -k 8001/tcp
+        run: fuser -k 8001/tcp
 
       - name: Upload artifact for screenshots & videos
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,26 +97,22 @@ jobs:
               foreach ($netTCPConnection in $netTCPConnections) {
                 $processId = $netTCPConnection.OwningProcess
                 Write-Host "Found ID $processId"
-                if ($processId -ne 0 -and $processId -ne 4) {  # Ensure we're not targeting the Idle or System process
-                  $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
-                  if ($process) {
-                    Write-Host "Found valid process $process"
-                    if ($process.Name -notcontains "Idle" -and $process.Name -notcontains "System") {
-                      try {
-                        Write-Host "Attempting to kill ID $processId with name $process.Name."
-                        Stop-Process -Id $process.Id -Force
-                        Write-Host "Process with ID $processId on port $port killed."
-                      } catch {
-                        Write-Host "Failed to kill process with ID $processId - $_"
-                      }
-                    } else {
-                      Write-Host "The process using port $port is a system process and cannot be terminated."
+                $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
+                if ($process) {
+                  Write-Host "Found valid process $process"
+                  if ($process.Name -notcontains "Idle" -and $process.Name -notcontains "System") {
+                    try {
+                      Write-Host "Attempting to kill ID $processId with name $process.Name."
+                      Stop-Process -Id $process.Id -Force
+                      Write-Host "Process with ID $processId on port $port killed."
+                    } catch {
+                      Write-Host "Failed to kill process with ID $processId - $_"
                     }
                   } else {
-                    Write-Host "No process found using port $port."
+                    Write-Host "The process using port $port is a system process and cannot be terminated."
                   }
                 } else {
-                  Write-Host "The process using port $port is a system process and cannot be terminated."
+                  Write-Host "No process found using port $port."
                 }
               }
             } else {
@@ -133,26 +129,22 @@ jobs:
               foreach ($netTCPConnection in $netTCPConnections) {
                 $processId = $netTCPConnection.OwningProcess
                 Write-Host "Found ID $processId"
-                if ($processId -ne 0 -and $processId -ne 4) {  # Ensure we're not targeting the Idle or System process
-                  $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
-                  if ($process) {
-                    Write-Host "Found valid process $process"
-                    if ($process.Name -notcontains "Idle" -and $process.Name -notcontains "System") {
-                      try {
-                        Write-Host "Attempting to kill ID $processId with name $process.Name."
-                        Stop-Process -Id $process.Id -Force
-                        Write-Host "Process with ID $processId on port $port killed."
-                      } catch {
-                        Write-Host "Failed to kill process with ID $processId - $_"
-                      }
-                    } else {
-                      Write-Host "The process using port $port is a system process and cannot be terminated."
+                $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
+                if ($process) {
+                  Write-Host "Found valid process $process"
+                  if ($process.Name -notcontains "Idle" -and $process.Name -notcontains "System") {
+                    try {
+                      Write-Host "Attempting to kill ID $processId with name $process.Name."
+                      Stop-Process -Id $process.Id -Force
+                      Write-Host "Process with ID $processId on port $port killed."
+                    } catch {
+                      Write-Host "Failed to kill process with ID $processId - $_"
                     }
                   } else {
-                    Write-Host "No process found using port $port."
+                    Write-Host "The process using port $port is a system process and cannot be terminated."
                   }
                 } else {
-                  Write-Host "The process using port $port is a system process and cannot be terminated."
+                  Write-Host "No process found using port $port."
                 }
               }
             } else {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,10 +88,10 @@ jobs:
         if: runner.os == 'Linux'
         run: fuser -k 8001/tcp
 
-      - name: stop windows frontend service
+      - name: stop windows backend service
         if: runner.os == 'Windows'
         run: |
-            $port = 3000
+            $port = 8001
             $netTCPConnection = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
             if ($netTCPConnection) {
               $processId = $netTCPConnection.OwningProcess
@@ -99,6 +99,7 @@ jobs:
                 $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
                 if ($process) {
                   if ($process.Name -ne "Idle" -and $process.Name -ne "System") {
+                    Write-Host "Killing $process.Name with id $processId."
                     Stop-Process -Id $process.Id -Force
                     Write-Host "Process on port $port killed."
                   } else {
@@ -115,10 +116,10 @@ jobs:
             }
         shell: pwsh
 
-      - name: stop windows backend service
+      - name: stop windows frontend service
         if: runner.os == 'Windows'
         run: |
-            $port = 8001
+            $port = 3000
             $netTCPConnection = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
             if ($netTCPConnection) {
               $processId = $netTCPConnection.OwningProcess
@@ -126,6 +127,7 @@ jobs:
                 $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
                 if ($process) {
                   if ($process.Name -ne "Idle" -and $process.Name -ne "System") {
+                    Write-Host "Killing $process.Name with id $processId."
                     Stop-Process -Id $process.Id -Force
                     Write-Host "Process on port $port killed."
                   } else {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
                   $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
                   if ($process) {
                     Write-Host "Found valid process $process"
-                    if ($process.Name -notcontains "Idle" -and $process.Name -notcontains "System") {
+                    if ($process.Name -notcontains "Idle") {
                       try {
                         Write-Host "Attempting to kill ID $processId with name $process.Name."
                         Stop-Process -Id $process.Id -Force
@@ -110,7 +110,7 @@ jobs:
                         Write-Host "Failed to kill process with ID $processId - $_"
                       }
                     } else {
-                      Write-Host "The process using port $port is a system process and cannot be terminated."
+                      Write-Host "The process using port $port is the idle process and cannot be terminated."
                     }
                   } else {
                     Write-Host "No process found using port $port."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,9 +94,9 @@ jobs:
             $port = 3000
             $netTCPConnection = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
             if ($netTCPConnection) {
-              $pid = $netTCPConnection.OwningProcess
-              if ($pid -ne 0) {  # Ensure we're not targeting the Idle process
-                $process = Get-Process -Id $pid -ErrorAction SilentlyContinue
+              $processId = $netTCPConnection.OwningProcess
+              if ($processId -ne 0) {  # Ensure we're not targeting the Idle process
+                $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
                 if ($process) {
                   Stop-Process -Id $process.Id -Force
                   Write-Host "Process on port $port killed."
@@ -117,9 +117,9 @@ jobs:
             $port = 8001
             $netTCPConnection = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
             if ($netTCPConnection) {
-              $pid = $netTCPConnection.OwningProcess
-              if ($pid -ne 0) {  # Ensure we're not targeting the Idle process
-                $process = Get-Process -Id $pid -ErrorAction SilentlyContinue
+              $processId = $netTCPConnection.OwningProcess
+              if ($processId -ne 0) {  # Ensure we're not targeting the Idle process
+                $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
                 if ($process) {
                   Stop-Process -Id $process.Id -Force
                   Write-Host "Process on port $port killed."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,11 +80,21 @@ jobs:
         timeout-minutes: 45
         run: npx cypress run
 
-      - name: stop frontend service
+      - name: stop linux frontend service
+        if: runner.os == 'Linux'
         run: fuser -k 3000/tcp
 
-      - name: stop backend service
+      - name: stop linux backend service
+        if: runner.os == 'Linux'
         run: fuser -k 8001/tcp
+
+      - name: stop windows frontend service
+        if: runner.os == 'Windows'
+        run: for /f "tokens=5" %a in ('netstat -aon ^| findstr :3000') do taskkill /PID %a /F
+
+      - name: stop windows backend service
+        if: runner.os == 'Windows'
+        run: for /f "tokens=5" %a in ('netstat -aon ^| findstr :8001') do taskkill /PID %a /F
 
       - name: Upload artifact for screenshots & videos
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,67 +88,37 @@ jobs:
         if: runner.os == 'Linux'
         run: fuser -k 8001/tcp
 
-      - name: stop windows backend service
+      - name: stop windows services
         if: runner.os == 'Windows'
         run: |
-            $port = 8001
-            $netTCPConnections = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
-            if ($netTCPConnections) {
-              foreach ($netTCPConnection in $netTCPConnections) {
-                $processId = $netTCPConnection.OwningProcess
-                Write-Host "Found ID $processId"
-                $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
-                if ($process) {
-                  Write-Host "Found valid process $process"
-                  if ($process.Name -notcontains "Idle" -and $process.Name -notcontains "System") {
-                    try {
-                      Write-Host "Attempting to kill ID $processId with name $process.Name."
-                      Stop-Process -Id $process.Id -Force
-                      Write-Host "Process with ID $processId on port $port killed."
-                    } catch {
-                      Write-Host "Failed to kill process with ID $processId - $_"
+            $ports = @(3000, 8001)
+            foreach ($port in $ports){
+              $netTCPConnections = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
+              if ($netTCPConnections) {
+                foreach ($netTCPConnection in $netTCPConnections) {
+                  $processId = $netTCPConnection.OwningProcess
+                  Write-Host "Found ID $processId"
+                  $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
+                  if ($process) {
+                    Write-Host "Found valid process $process"
+                    if ($process.Name -notcontains "Idle" -and $process.Name -notcontains "System") {
+                      try {
+                        Write-Host "Attempting to kill ID $processId with name $process.Name."
+                        Stop-Process -Id $process.Id -Force
+                        Write-Host "Process with ID $processId on port $port killed."
+                      } catch {
+                        Write-Host "Failed to kill process with ID $processId - $_"
+                      }
+                    } else {
+                      Write-Host "The process using port $port is a system process and cannot be terminated."
                     }
                   } else {
-                    Write-Host "The process using port $port is a system process and cannot be terminated."
+                    Write-Host "No process found using port $port."
                   }
-                } else {
-                  Write-Host "No process found using port $port."
                 }
+              } else {
+                Write-Host "No TCP connection found on port $port."
               }
-            } else {
-              Write-Host "No TCP connection found on port $port."
-            }
-        shell: pwsh
-
-      - name: stop windows frontend service
-        if: runner.os == 'Windows'
-        run: |
-            $port = 3000
-            $netTCPConnections = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
-            if ($netTCPConnections) {
-              foreach ($netTCPConnection in $netTCPConnections) {
-                $processId = $netTCPConnection.OwningProcess
-                Write-Host "Found ID $processId"
-                $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
-                if ($process) {
-                  Write-Host "Found valid process $process"
-                  if ($process.Name -notcontains "Idle" -and $process.Name -notcontains "System") {
-                    try {
-                      Write-Host "Attempting to kill ID $processId with name $process.Name."
-                      Stop-Process -Id $process.Id -Force
-                      Write-Host "Process with ID $processId on port $port killed."
-                    } catch {
-                      Write-Host "Failed to kill process with ID $processId - $_"
-                    }
-                  } else {
-                    Write-Host "The process using port $port is a system process and cannot be terminated."
-                  }
-                } else {
-                  Write-Host "No process found using port $port."
-                }
-              }
-            } else {
-              Write-Host "No TCP connection found on port $port."
             }
         shell: pwsh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,10 +96,12 @@ jobs:
             if ($netTCPConnections) {
               foreach ($netTCPConnection in $netTCPConnections) {
                 $processId = $netTCPConnection.OwningProcess
+                Write-Host "Found ID $processId"
                 if ($processId -ne 0 -and $processId -ne 4) {  # Ensure we're not targeting the Idle or System process
                   $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
                   if ($process) {
-                    if ($process.Name -ne "Idle" -and $process.Name -ne "System") {
+                    Write-Host "Found valid process $process"
+                    if ($process.Name -notcontains "Idle" -and $process.Name -notcontains "System") {
                       try {
                         Write-Host "Attempting to kill ID $processId with name $process.Name."
                         Stop-Process -Id $process.Id -Force
@@ -130,10 +132,12 @@ jobs:
             if ($netTCPConnections) {
               foreach ($netTCPConnection in $netTCPConnections) {
                 $processId = $netTCPConnection.OwningProcess
+                Write-Host "Found ID $processId"
                 if ($processId -ne 0 -and $processId -ne 4) {  # Ensure we're not targeting the Idle or System process
                   $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
                   if ($process) {
-                    if ($process.Name -ne "Idle" -and $process.Name -ne "System") {
+                    Write-Host "Found valid process $process"
+                    if ($process.Name -notcontains "Idle" -and $process.Name -notcontains "System") {
                       try {
                         Write-Host "Attempting to kill ID $processId with name $process.Name."
                         Stop-Process -Id $process.Id -Force

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,15 +94,20 @@ jobs:
             $port = 3000
             $netTCPConnection = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
             if ($netTCPConnection) {
-            $process = Get-Process -Id $netTCPConnection.OwningProcess -ErrorAction SilentlyContinue
-            if ($process) {
-                Stop-Process -Id $process.Id -Force
-                Write-Host "Process on port $port killed."
+              $pid = $netTCPConnection.OwningProcess
+              if ($pid -ne 0) {  # Ensure we're not targeting the Idle process
+                $process = Get-Process -Id $pid -ErrorAction SilentlyContinue
+                if ($process) {
+                  Stop-Process -Id $process.Id -Force
+                  Write-Host "Process on port $port killed."
+                } else {
+                  Write-Host "No process found using port $port."
+                }
+              } else {
+                Write-Host "The process using port $port is a system process and cannot be terminated."
+              }
             } else {
-                Write-Host "No process found using port $port."
-            }
-            } else {
-            Write-Host "No TCP connection found on port $port."
+              Write-Host "No TCP connection found on port $port."
             }
         shell: pwsh
 
@@ -112,15 +117,20 @@ jobs:
             $port = 8001
             $netTCPConnection = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
             if ($netTCPConnection) {
-            $process = Get-Process -Id $netTCPConnection.OwningProcess -ErrorAction SilentlyContinue
-            if ($process) {
-                Stop-Process -Id $process.Id -Force
-                Write-Host "Process on port $port killed."
+              $pid = $netTCPConnection.OwningProcess
+              if ($pid -ne 0) {  # Ensure we're not targeting the Idle process
+                $process = Get-Process -Id $pid -ErrorAction SilentlyContinue
+                if ($process) {
+                  Stop-Process -Id $process.Id -Force
+                  Write-Host "Process on port $port killed."
+                } else {
+                  Write-Host "No process found using port $port."
+                }
+              } else {
+                Write-Host "The process using port $port is a system process and cannot be terminated."
+              }
             } else {
-                Write-Host "No process found using port $port."
-            }
-            } else {
-            Write-Host "No TCP connection found on port $port."
+              Write-Host "No TCP connection found on port $port."
             }
         shell: pwsh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,7 @@ jobs:
                         Stop-Process -Id $process.Id -Force
                         Write-Host "Process with ID $processId on port $port killed."
                       } catch {
-                        Write-Host "Failed to kill process with ID $processId: $_"
+                        Write-Host "Failed to kill process with ID $processId - $_"
                       }
                     } else {
                       Write-Host "The process using port $port is a system process and cannot be terminated."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,13 +80,9 @@ jobs:
         timeout-minutes: 45
         run: npx cypress run
 
-      - name: stop linux frontend service
+      - name: stop linux services
         if: runner.os == 'Linux'
-        run: fuser -k 3000/tcp
-
-      - name: stop linux backend service
-        if: runner.os == 'Linux'
-        run: fuser -k 8001/tcp
+        run: fuser -k 3000/tcp && fuser -k 8001/tcp
 
       - name: stop windows services
         if: runner.os == 'Windows'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,7 +139,7 @@ jobs:
                         Stop-Process -Id $process.Id -Force
                         Write-Host "Process with ID $processId on port $port killed."
                       } catch {
-                        Write-Host "Failed to kill process with ID $processId: $_"
+                        Write-Host "Failed to kill process with ID $processId - $_"
                       }
                     } else {
                       Write-Host "The process using port $port is a system process and cannot be terminated."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,11 +95,15 @@ jobs:
             $netTCPConnection = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
             if ($netTCPConnection) {
               $processId = $netTCPConnection.OwningProcess
-              if ($processId -ne 0) {  # Ensure we're not targeting the Idle process
+              if ($processId -ne 0 -and $processId -ne 4) {  # Ensure we're not targeting the Idle or System process
                 $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
                 if ($process) {
-                  Stop-Process -Id $process.Id -Force
-                  Write-Host "Process on port $port killed."
+                  if ($process.Name -ne "Idle" -and $process.Name -ne "System") {
+                    Stop-Process -Id $process.Id -Force
+                    Write-Host "Process on port $port killed."
+                  } else {
+                    Write-Host "The process using port $port is a system process and cannot be terminated."
+                  }
                 } else {
                   Write-Host "No process found using port $port."
                 }
@@ -118,11 +122,15 @@ jobs:
             $netTCPConnection = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
             if ($netTCPConnection) {
               $processId = $netTCPConnection.OwningProcess
-              if ($processId -ne 0) {  # Ensure we're not targeting the Idle process
+              if ($processId -ne 0 -and $processId -ne 4) {  # Ensure we're not targeting the Idle or System process
                 $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
                 if ($process) {
-                  Stop-Process -Id $process.Id -Force
-                  Write-Host "Process on port $port killed."
+                  if ($process.Name -ne "Idle" -and $process.Name -ne "System") {
+                    Stop-Process -Id $process.Id -Force
+                    Write-Host "Process on port $port killed."
+                  } else {
+                    Write-Host "The process using port $port is a system process and cannot be terminated."
+                  }
                 } else {
                   Write-Host "No process found using port $port."
                 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,12 @@ jobs:
         timeout-minutes: 45
         run: npx cypress run
 
+      - name: stop frontend service
+        run: sudo fuser -k 3000/tcp
+
+      - name: stop backend service
+        run: sudo fuser -k 8001/tcp
+
       - name: Upload artifact for screenshots & videos
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,24 +92,30 @@ jobs:
         if: runner.os == 'Windows'
         run: |
             $port = 8001
-            $netTCPConnection = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
-            if ($netTCPConnection) {
-              $processId = $netTCPConnection.OwningProcess
-              if ($processId -ne 0 -and $processId -ne 4) {  # Ensure we're not targeting the Idle or System process
-                $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
-                if ($process) {
-                  if ($process.Name -ne "Idle" -and $process.Name -ne "System") {
-                    Write-Host "Killing $process.Name with id $processId."
-                    Stop-Process -Id $process.Id -Force
-                    Write-Host "Process on port $port killed."
+            $netTCPConnections = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
+            if ($netTCPConnections) {
+              foreach ($netTCPConnection in $netTCPConnections) {
+                $processId = $netTCPConnection.OwningProcess
+                if ($processId -ne 0 -and $processId -ne 4) {  # Ensure we're not targeting the Idle or System process
+                  $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
+                  if ($process) {
+                    if ($process.Name -ne "Idle" -and $process.Name -ne "System") {
+                      try {
+                        Write-Host "Attempting to kill ID $processId with name $process.Name."
+                        Stop-Process -Id $process.Id -Force
+                        Write-Host "Process with ID $processId on port $port killed."
+                      } catch {
+                        Write-Host "Failed to kill process with ID $processId: $_"
+                      }
+                    } else {
+                      Write-Host "The process using port $port is a system process and cannot be terminated."
+                    }
                   } else {
-                    Write-Host "The process using port $port is a system process and cannot be terminated."
+                    Write-Host "No process found using port $port."
                   }
                 } else {
-                  Write-Host "No process found using port $port."
+                  Write-Host "The process using port $port is a system process and cannot be terminated."
                 }
-              } else {
-                Write-Host "The process using port $port is a system process and cannot be terminated."
               }
             } else {
               Write-Host "No TCP connection found on port $port."
@@ -120,24 +126,30 @@ jobs:
         if: runner.os == 'Windows'
         run: |
             $port = 3000
-            $netTCPConnection = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
-            if ($netTCPConnection) {
-              $processId = $netTCPConnection.OwningProcess
-              if ($processId -ne 0 -and $processId -ne 4) {  # Ensure we're not targeting the Idle or System process
-                $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
-                if ($process) {
-                  if ($process.Name -ne "Idle" -and $process.Name -ne "System") {
-                    Write-Host "Killing $process.Name with id $processId."
-                    Stop-Process -Id $process.Id -Force
-                    Write-Host "Process on port $port killed."
+            $netTCPConnections = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
+            if ($netTCPConnections) {
+              foreach ($netTCPConnection in $netTCPConnections) {
+                $processId = $netTCPConnection.OwningProcess
+                if ($processId -ne 0 -and $processId -ne 4) {  # Ensure we're not targeting the Idle or System process
+                  $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
+                  if ($process) {
+                    if ($process.Name -ne "Idle" -and $process.Name -ne "System") {
+                      try {
+                        Write-Host "Attempting to kill ID $processId with name $process.Name."
+                        Stop-Process -Id $process.Id -Force
+                        Write-Host "Process with ID $processId on port $port killed."
+                      } catch {
+                        Write-Host "Failed to kill process with ID $processId: $_"
+                      }
+                    } else {
+                      Write-Host "The process using port $port is a system process and cannot be terminated."
+                    }
                   } else {
-                    Write-Host "The process using port $port is a system process and cannot be terminated."
+                    Write-Host "No process found using port $port."
                   }
                 } else {
-                  Write-Host "No process found using port $port."
+                  Write-Host "The process using port $port is a system process and cannot be terminated."
                 }
-              } else {
-                Write-Host "The process using port $port is a system process and cannot be terminated."
               }
             } else {
               Write-Host "No TCP connection found on port $port."


### PR DESCRIPTION
Issue: Since expanding the test suite, failures on `Post run actions/checkout` occur intermittently. This may be due to the running processes (backend, frontend) starving the VM of CPU or memory. See below:

![Screenshot 2024-08-01 at 11 38 01 AM](https://github.com/user-attachments/assets/40a9b561-2375-4dba-bbdb-82a17b923ae7)

Solution: terminate backend and frontend processes after tests finish running