### PR TITLE
Input change flag

### DIFF
--- a/electron/ui/cypress/e2e/FlowsheetTesting.cy.js
+++ b/electron/ui/cypress/e2e/FlowsheetTesting.cy.js
@@ -269,9 +269,9 @@ describe('WaterTAP UI Testing', () => {
 
     // })
 
-    it('input change flag for RO with energy recovery value change- fixed/free change', () => {
+    it('input change flag for RO with energy recovery value change- bounds change', () => {
         cy.load_flowsheets_list()
-        cy.screenshot('fixed/free: loaded flowsheet list page')
+        cy.screenshot('bounds: loaded flowsheet list page')
         
         const flowsheet_name = 'RO with energy recovery flowsheet'
         
@@ -279,18 +279,18 @@ describe('WaterTAP UI Testing', () => {
         
         // load flowsheet
         cy.load_flowsheet(flowsheet.name)
-        cy.screenshot('fixed/free: loaded '+flowsheet.name)
+        cy.screenshot('bounds: loaded '+flowsheet.name)
 
         // solve flowsheet
         cy.solve_flowsheet()
-        cy.screenshot("fixed/free: solved "+flowsheet.name)
+        cy.screenshot("bounds: solved "+flowsheet.name)
 
 
         cy.findByRole('tab', {name: /output/i}).click();
 
         // check no flag
         cy.get('#inputChangeFlag').should('not.exist');
-        cy.screenshot('fixed/free: no-input-change-no-flag-'+flowsheet.name)
+        cy.screenshot('bounds: no-input-change-no-flag-'+flowsheet.name)
 
         cy.findByRole('tab', {name: /input/i}).click();
 
@@ -300,7 +300,7 @@ describe('WaterTAP UI Testing', () => {
         cy.wait(100)
         cy.findByRole('option', { name: /free/i }).click()
         cy.wait(100)
-        cy.screenshot('fixed/free: change-option-free '+flowsheet.name)
+        cy.screenshot('bounds: change-option-free '+flowsheet.name)
 
         // enter lower and upper bounds
         cy.enter_text('class', flowsheet.sweepVariable+'_lower_input', flowsheet.sweepValues[0])
@@ -312,7 +312,7 @@ describe('WaterTAP UI Testing', () => {
 
         // check for flag 
         cy.get('#inputChangeFlag').should('exist');
-        cy.screenshot('fixed/free: output-flag-after-input-change-flag ' + flowsheet.name);
+        cy.screenshot('bounds: output-flag-after-input-change-flag ' + flowsheet.name);
         
         // return to inputs 
         cy.findByRole('tab', {name: /input/i}).click();
@@ -322,6 +322,6 @@ describe('WaterTAP UI Testing', () => {
 
         // check no flag after solving again
         cy.get('#inputChangeFlag').should('not.exist');
-        cy.screenshot("fixed/free: re-solved-after-input-change-no-flag "+flowsheet_name)
+        cy.screenshot("bounds: re-solved-after-input-change-no-flag "+flowsheet_name)
     })
 })

--- a/electron/ui/cypress/e2e/FlowsheetTesting.cy.js
+++ b/electron/ui/cypress/e2e/FlowsheetTesting.cy.js
@@ -175,7 +175,7 @@ describe('WaterTAP UI Testing', () => {
 
     // RO is most kikely the most canonical 
     // Exclusively run on 'RO with energy recovery flowsheet'
-    it('input change flag for RO with energy recovery value change', () => {
+    it('input change flag for RO with energy recovery- value change', () => {
         cy.load_flowsheets_list()
         cy.screenshot('loaded flowsheet list page')
         
@@ -191,12 +191,11 @@ describe('WaterTAP UI Testing', () => {
 
         // check no flag
         cy.get('#inputChangeFlag').should('not.exist');
-        cy.screenshot('no-input-change-no-flag-'+flowsheet_name)
+        cy.screenshot('value: no-input-change-no-flag-'+flowsheet_name)
 
         // go to inputs
         cy.findByRole('tab', {name: /input/i}).click();
-        cy.screenshot('input-tab-click-' + flowsheet_name);
-        let username; 
+        cy.screenshot('value: input-tab-click-' + flowsheet_name);
 
         cy.findByRole('textbox', {name: 'Water mass flowrate'}).invoke('val').then((val) => {
             const changed_val = val * 1.02
@@ -205,7 +204,7 @@ describe('WaterTAP UI Testing', () => {
             cy.enter_text('role' ,'textbox', changed_val, 'Water mass flowrate')
 
             // Take the screenshot after the input has v has been logged
-            cy.screenshot('input-change-' + flowsheet_name);
+            cy.screenshot('value: input-change-' + flowsheet_name);
             
         });
 
@@ -214,7 +213,7 @@ describe('WaterTAP UI Testing', () => {
 
         // check for flag 
         cy.get('#inputChangeFlag').should('exist');
-        cy.screenshot('output-flag-after-input-change-flag' + flowsheet_name);
+        cy.screenshot('value: output-flag-after-input-change-flag' + flowsheet_name);
 
         // return to inputs 
         cy.findByRole('tab', {name: /input/i}).click();
@@ -224,7 +223,105 @@ describe('WaterTAP UI Testing', () => {
 
         // check no flag after solving again
         cy.get('#inputChangeFlag').should('not.exist');
-        cy.screenshot("re-solved-after-input-change-no-flag "+flowsheet_name)
+        cy.screenshot("value: re-solved-after-input-change-no-flag "+flowsheet_name)
     })
 
+    // it('input change flag for RO with energy recovery value change- fixed/free change', () => {
+    //     cy.load_flowsheets_list()
+    //     cy.screenshot('fixed/free: loaded flowsheet list page')
+        
+    //     const flowsheet_name = 'RO with energy recovery flowsheet'
+        
+    //     const flowsheet = flowsheets.find(flowsheet => flowsheet.name === flowsheet_name);
+        
+    //     // load flowsheet
+    //     cy.load_flowsheet(flowsheet.name)
+    //     cy.screenshot('fixed/free: loaded '+flowsheet.name)
+
+    //     // solve flowsheet
+    //     cy.solve_flowsheet()
+    //     cy.screenshot("fixed/free: solved "+flowsheet.name)
+
+
+    //     cy.findByRole('tab', {name: /output/i}).click();
+
+    //     // check no flag
+    //     cy.get('#inputChangeFlag').should('not.exist');
+    //     cy.screenshot('fixed/free: no-input-change-no-flag-'+flowsheet.name)
+
+    //     cy.findByRole('tab', {name: /input/i}).click();
+
+
+    //     // set free variable
+    //     cy.get('.'+flowsheet.sweepVariable+'_fixed-free-select').click()
+    //     cy.wait(100)
+    //     cy.findByRole('option', { name: /free/i }).click()
+    //     cy.wait(100)
+    //     cy.screenshot('fixed/free: change-option-free '+flowsheet.name)
+
+    //     // go to outputs
+    //     cy.findByRole('tab', {name: /output/i}).click()
+    //     cy.screenshot('fixed/free: LOOK' + flowsheet.name);
+
+    //     // // check for flag 
+    //     // cy.get('#inputChangeFlag').should('exist');
+    //     // cy.screenshot('fixed/free: output-flag-after-input-change-flag ' + flowsheet.name);
+
+    // })
+
+    it('input change flag for RO with energy recovery value change- fixed/free change', () => {
+        cy.load_flowsheets_list()
+        cy.screenshot('fixed/free: loaded flowsheet list page')
+        
+        const flowsheet_name = 'RO with energy recovery flowsheet'
+        
+        const flowsheet = flowsheets.find(flowsheet => flowsheet.name === flowsheet_name);
+        
+        // load flowsheet
+        cy.load_flowsheet(flowsheet.name)
+        cy.screenshot('fixed/free: loaded '+flowsheet.name)
+
+        // solve flowsheet
+        cy.solve_flowsheet()
+        cy.screenshot("fixed/free: solved "+flowsheet.name)
+
+
+        cy.findByRole('tab', {name: /output/i}).click();
+
+        // check no flag
+        cy.get('#inputChangeFlag').should('not.exist');
+        cy.screenshot('fixed/free: no-input-change-no-flag-'+flowsheet.name)
+
+        cy.findByRole('tab', {name: /input/i}).click();
+
+
+        // set free variable
+        cy.get('.'+flowsheet.sweepVariable+'_fixed-free-select').click()
+        cy.wait(100)
+        cy.findByRole('option', { name: /free/i }).click()
+        cy.wait(100)
+        cy.screenshot('fixed/free: change-option-free '+flowsheet.name)
+
+        // enter lower and upper bounds
+        cy.enter_text('class', flowsheet.sweepVariable+'_lower_input', flowsheet.sweepValues[0])
+        cy.enter_text('class', flowsheet.sweepVariable+'_upper_input', flowsheet.sweepValues[1])
+
+
+        // go to outputs
+        cy.findByRole('tab', {name: /output/i}).click()
+
+        // check for flag 
+        cy.get('#inputChangeFlag').should('exist');
+        cy.screenshot('fixed/free: output-flag-after-input-change-flag ' + flowsheet.name);
+        
+        // return to inputs 
+        cy.findByRole('tab', {name: /input/i}).click();
+
+        // solve flowsheet
+        cy.solve_flowsheet()
+
+        // check no flag after solving again
+        cy.get('#inputChangeFlag').should('not.exist');
+        cy.screenshot("fixed/free: re-solved-after-input-change-no-flag "+flowsheet_name)
+    })
 })

--- a/electron/ui/cypress/e2e/FlowsheetTesting.cy.js
+++ b/electron/ui/cypress/e2e/FlowsheetTesting.cy.js
@@ -1,177 +1,177 @@
 import { flowsheets } from "./Flowsheets"
 describe('WaterTAP UI Testing', () => {
-    // it('tests flowsheets-list page', () => {
-    //     cy.load_flowsheets_list()
-    //     cy.screenshot('loaded flowsheet list page')
+    it('tests flowsheets-list page', () => {
+        cy.load_flowsheets_list()
+        cy.screenshot('loaded flowsheet list page')
 
-    //     // verify that heading and table headers are present
-    //     cy.findByRole('heading', {  name: /flowsheets/i})
-    //     cy.findByRole('columnheader', {  name: /flowsheet name/i})
-    //     cy.findByRole('columnheader', {  name: /last run/i})
-    //     cy.screenshot('end-list-page-test')  
-    // })
+        // verify that heading and table headers are present
+        cy.findByRole('heading', {  name: /flowsheets/i})
+        cy.findByRole('columnheader', {  name: /flowsheet name/i})
+        cy.findByRole('columnheader', {  name: /last run/i})
+        cy.screenshot('end-list-page-test')  
+    })
 
-    // it('tests invalid inputs', () => {
-    //     cy.load_flowsheets_list()
-    //     cy.screenshot('loaded flowsheet list page')
+    it('tests invalid inputs', () => {
+        cy.load_flowsheets_list()
+        cy.screenshot('loaded flowsheet list page')
         
-    //     // load flowsheet
-    //     cy.load_flowsheet("RO with energy recovery flowsheet")
-    //     cy.screenshot('loaded RO flowsheet');
+        // load flowsheet
+        cy.load_flowsheet("RO with energy recovery flowsheet")
+        cy.screenshot('loaded RO flowsheet');
 
-    //     // set invalid text input. do it twice to ensure it registers in slow windows runner
-    //     cy.set_ro_flowrate('dfas');
-    //     cy.wait(1000)
-    //     cy.set_ro_flowrate('dfas');
-    //     cy.wait(1000)
-    //     cy.screenshot('invalid-text-input');
+        // set invalid text input. do it twice to ensure it registers in slow windows runner
+        cy.set_ro_flowrate('dfas');
+        cy.wait(1000)
+        cy.set_ro_flowrate('dfas');
+        cy.wait(1000)
+        cy.screenshot('invalid-text-input');
 
-    //     // solve flowsheet
-    //     cy.solve_flowsheet()
+        // solve flowsheet
+        cy.solve_flowsheet()
 
-    //     // verify that error message is there
-    //     cy.screenshot('error-message');
-    //     cy.get('.error-message').should('be.visible')
+        // verify that error message is there
+        cy.screenshot('error-message');
+        cy.get('.error-message').should('be.visible')
 
-    //     // reset flowsheet
-    //     cy.reset_flowsheet()
-    //     cy.screenshot('end-invalid-input-test');
-    // })
+        // reset flowsheet
+        cy.reset_flowsheet()
+        cy.screenshot('end-invalid-input-test');
+    })
 
-    // it('tests logging panel', () => {
-    //     cy.load_flowsheets_list()
-    //     cy.wait(2000)
-    //     cy.screenshot('loaded flowsheet list page')
+    it('tests logging panel', () => {
+        cy.load_flowsheets_list()
+        cy.wait(2000)
+        cy.screenshot('loaded flowsheet list page')
         
-    //     // open logging panel
-    //     cy.open_logging_panel()
-    //     cy.screenshot('opened_logs')
+        // open logging panel
+        cy.open_logging_panel()
+        cy.screenshot('opened_logs')
 
-    //     // verify that a log line of type info and warning are present
-    //     cy.get('.log-line').contains('INFO')
-    //     cy.get('.log-line').contains('WARNING')
-    //     cy.screenshot('end-logging-test')
-    // })
+        // verify that a log line of type info and warning are present
+        cy.get('.log-line').contains('INFO')
+        cy.get('.log-line').contains('WARNING')
+        cy.screenshot('end-logging-test')
+    })
 
-    // it('tests new flowsheet', () => {
-    //     let modelFile = "https://drive.google.com/uc?export=download&id=1XdjuWNpYT9teZxaF8TuwDz0XS2XyXKeT"
-    //     let exportFile = "https://drive.google.com/uc?export=download&id=1-jWQmI4wO2OlyUi32fqobFEmPn3zm9Q9"
-    //     cy.load_flowsheets_list()
-    //     cy.screenshot('loaded flowsheet list page')
+    it('tests new flowsheet', () => {
+        let modelFile = "https://drive.google.com/uc?export=download&id=1XdjuWNpYT9teZxaF8TuwDz0XS2XyXKeT"
+        let exportFile = "https://drive.google.com/uc?export=download&id=1-jWQmI4wO2OlyUi32fqobFEmPn3zm9Q9"
+        cy.load_flowsheets_list()
+        cy.screenshot('loaded flowsheet list page')
 
-    //     // download model and export files
-    //     cy.downloadFile(modelFile,'cypress/downloads','testModelFile.py')
-    //     cy.downloadFile(exportFile,'cypress/downloads','testModelFile_ui.py')
+        // download model and export files
+        cy.downloadFile(modelFile,'cypress/downloads','testModelFile.py')
+        cy.downloadFile(exportFile,'cypress/downloads','testModelFile_ui.py')
         
-    //     // click new flowsheet button
-    //     cy.findByRole('button', {name: /new flowsheet +/i}).click()
-    //     cy.wait(500)
-    //     cy.screenshot("clicked new flowsheet")
+        // click new flowsheet button
+        cy.findByRole('button', {name: /new flowsheet +/i}).click()
+        cy.wait(500)
+        cy.screenshot("clicked new flowsheet")
         
-    //     // select both files
-    //     cy.get('.ModelFile').selectFile('./cypress/downloads/testModelFile.py', {
-    //         action: 'drag-drop',
-    //         force: true
-    //     })
-    //     cy.get('.ExportFile').selectFile('./cypress/downloads/testModelFile_ui.py', {
-    //         action: 'drag-drop',
-    //         force: true
-    //     })
-    //     cy.wait(500)
-    //     cy.screenshot("dragged and dropped files")
+        // select both files
+        cy.get('.ModelFile').selectFile('./cypress/downloads/testModelFile.py', {
+            action: 'drag-drop',
+            force: true
+        })
+        cy.get('.ExportFile').selectFile('./cypress/downloads/testModelFile_ui.py', {
+            action: 'drag-drop',
+            force: true
+        })
+        cy.wait(500)
+        cy.screenshot("dragged and dropped files")
 
-    //     // click upload
-    //     cy.get('.upload-flowsheet-button').click()
-    //     cy.wait(1000)
-    //     cy.screenshot("uploaded files")
+        // click upload
+        cy.get('.upload-flowsheet-button').click()
+        cy.wait(1000)
+        cy.screenshot("uploaded files")
 
-    //     // verify that flowsheet is now in list
-    //     cy.get('.flowsheet-name').contains(/test custom flowsheet/i)
-    //     cy.screenshot('end-new-flowsheet-test')
+        // verify that flowsheet is now in list
+        cy.get('.flowsheet-name').contains(/test custom flowsheet/i)
+        cy.screenshot('end-new-flowsheet-test')
 
-    // })
+    })
 
-    // flowsheets.forEach((flowsheet) => {
-    //     it('tests optimization for '+flowsheet.name, () => {
-    //         cy.load_flowsheets_list()
-    //         cy.wait(2000)
-    //         cy.screenshot('loaded flowsheet list page')
+    flowsheets.forEach((flowsheet) => {
+        it('tests optimization for '+flowsheet.name, () => {
+            cy.load_flowsheets_list()
+            cy.wait(2000)
+            cy.screenshot('loaded flowsheet list page')
             
-    //         // load flowsheet
-    //         cy.load_flowsheet(flowsheet.name)
-    //         cy.screenshot('loaded '+flowsheet.name);
+            // load flowsheet
+            cy.load_flowsheet(flowsheet.name)
+            cy.screenshot('loaded '+flowsheet.name);
             
-    //         // if model has build options, it must be manually built
-    //         if (flowsheet.buildRequired) {
-    //             cy.build_flowsheet()
-    //             cy.screenshot("built "+flowsheet.name)
-    //         }
+            // if model has build options, it must be manually built
+            if (flowsheet.buildRequired) {
+                cy.build_flowsheet()
+                cy.screenshot("built "+flowsheet.name)
+            }
 
-    //         // solve flowsheet
-    //         cy.solve_flowsheet()
-    //         cy.screenshot("solved "+flowsheet.name)
+            // solve flowsheet
+            cy.solve_flowsheet()
+            cy.screenshot("solved "+flowsheet.name)
     
-    //         // Click save configuration button
-    //         cy.findByRole('button', {name: /save configuration/i}).click()
-    //         cy.wait(1000)
-    //         cy.screenshot('pre saveConfig for '+flowsheet.name)
+            // Click save configuration button
+            cy.findByRole('button', {name: /save configuration/i}).click()
+            cy.wait(1000)
+            cy.screenshot('pre saveConfig for '+flowsheet.name)
             
-    //         // Clear preset name and enter new name
-    //         cy.wait(1000)
-    //         cy.get('.MuiInput-input').should('be.visible')
-    //         cy.get('.MuiInput-input', {timeout: 10000}).clear({force: true})
-    //         cy.get('.MuiInput-input', {timeout: 10000}).type('new_test_configuration', {force: true})
-    //         cy.screenshot('saveConfig')
+            // Clear preset name and enter new name
+            cy.wait(1000)
+            cy.get('.MuiInput-input').should('be.visible')
+            cy.get('.MuiInput-input', {timeout: 10000}).clear({force: true})
+            cy.get('.MuiInput-input', {timeout: 10000}).type('new_test_configuration', {force: true})
+            cy.screenshot('saveConfig')
     
-    //         // Click on save (config) and wait for api response
-    //         cy.save_configuration()
-    //         cy.screenshot('saved config for '+flowsheet.name)
+            // Click on save (config) and wait for api response
+            cy.save_configuration()
+            cy.screenshot('saved config for '+flowsheet.name)
     
-    //         // Click compare tab
-    //         cy.findByRole('tab', {name: /compare/i}).click()
-    //         cy.wait(5000)
+            // Click compare tab
+            cy.findByRole('tab', {name: /compare/i}).click()
+            cy.wait(5000)
     
-    //         // Verify that new name is shown in comparison table
-    //         cy.findAllByRole('tabpanel', {name: /compare/i})
-    //         cy.screenshot('end-solve-'+flowsheet.name)
-    //     })
-    // })
+            // Verify that new name is shown in comparison table
+            cy.findAllByRole('tabpanel', {name: /compare/i})
+            cy.screenshot('end-solve-'+flowsheet.name)
+        })
+    })
 
-    // flowsheets.forEach((flowsheet) => {
-    //     it('tests parameter sweep '+flowsheet.name, () => {
-    //         cy.load_flowsheets_list()
-    //         cy.screenshot('loaded flowsheet list page')
+    flowsheets.forEach((flowsheet) => {
+        it('tests parameter sweep '+flowsheet.name, () => {
+            cy.load_flowsheets_list()
+            cy.screenshot('loaded flowsheet list page')
             
-    //         // load flowsheet
-    //         cy.load_flowsheet(flowsheet.name)
-    //         cy.screenshot('loaded '+flowsheet.name)
+            // load flowsheet
+            cy.load_flowsheet(flowsheet.name)
+            cy.screenshot('loaded '+flowsheet.name)
 
-    //         // set solve type to sweep
-    //         cy.get('#solve-sweep-select').click()
-    //         cy.wait(100)
-    //         cy.get('#sweep-option').click()
-    //         cy.wait(1000)
+            // set solve type to sweep
+            cy.get('#solve-sweep-select').click()
+            cy.wait(100)
+            cy.get('#sweep-option').click()
+            cy.wait(1000)
 
-    //         // set sweep variable
-    //         cy.get('.'+flowsheet.sweepVariable+'_fixed-free-select').click()
-    //         cy.wait(100)
-    //         cy.findByRole('option', { name: /sweep/i }).click()
-    //         cy.wait(100)
+            // set sweep variable
+            cy.get('.'+flowsheet.sweepVariable+'_fixed-free-select').click()
+            cy.wait(100)
+            cy.findByRole('option', { name: /sweep/i }).click()
+            cy.wait(100)
 
-    //         // enter lower and upper bounds
-    //         cy.enter_text('class', flowsheet.sweepVariable+'_lower_input', flowsheet.sweepValues[0])
-    //         cy.enter_text('class', flowsheet.sweepVariable+'_upper_input', flowsheet.sweepValues[1])
+            // enter lower and upper bounds
+            cy.enter_text('class', flowsheet.sweepVariable+'_lower_input', flowsheet.sweepValues[0])
+            cy.enter_text('class', flowsheet.sweepVariable+'_upper_input', flowsheet.sweepValues[1])
 
-    //         // run sweep
-    //         cy.solve_flowsheet()
-    //         cy.wait(5000)
-    //         cy.screenshot('ran parameter sweep '+flowsheet.name)
+            // run sweep
+            cy.solve_flowsheet()
+            cy.wait(5000)
+            cy.screenshot('ran parameter sweep '+flowsheet.name)
 
-    //         // verify that sweep was successful
-    //         cy.get('.parameter-sweep-output-table').should('be.visible')
+            // verify that sweep was successful
+            cy.get('.parameter-sweep-output-table').should('be.visible')
 
-    //     })
-    // })
+        })
+    })
 
     // RO is most kikely the most canonical 
     // Exclusively run on 'RO with energy recovery flowsheet'

--- a/electron/ui/cypress/e2e/FlowsheetTesting.cy.js
+++ b/electron/ui/cypress/e2e/FlowsheetTesting.cy.js
@@ -172,4 +172,59 @@ describe('WaterTAP UI Testing', () => {
 
         })
     })
+
+    // RO is most kikely the most canonical 
+    // Exclusively run on 'RO with energy recovery flowsheet'
+    it('input change flag for RO with energy recovery value change', () => {
+        cy.load_flowsheets_list()
+        cy.screenshot('loaded flowsheet list page')
+        
+        const flowsheet_name = 'RO with energy recovery flowsheet'
+
+        // load flowsheet
+        cy.load_flowsheet(flowsheet_name)
+        cy.screenshot('loaded '+ flowsheet_name)
+
+        // solve flowsheet
+        cy.solve_flowsheet()
+        cy.screenshot("solved "+flowsheet_name)
+
+        // check no flag
+        cy.get('#inputChangeFlag').should('not.exist');
+        cy.screenshot('no-input-change-no-flag-'+flowsheet_name)
+
+        // go to inputs
+        cy.findByRole('tab', {name: /input/i}).click();
+        cy.screenshot('input-tab-click-' + flowsheet_name);
+        let username; 
+
+        cy.findByRole('textbox', {name: 'Water mass flowrate'}).invoke('val').then((val) => {
+            const changed_val = val * 1.02
+
+            // change input 
+            cy.enter_text('role' ,'textbox', changed_val, 'Water mass flowrate')
+
+            // Take the screenshot after the input has v has been logged
+            cy.screenshot('input-change-' + flowsheet_name);
+            
+        });
+
+        // go to outputs
+        cy.findByRole('tab', {name: /output/i}).click()
+
+        // check for flag 
+        cy.get('#inputChangeFlag').should('exist');
+        cy.screenshot('output-flag-after-input-change-flag' + flowsheet_name);
+
+        // return to inputs 
+        cy.findByRole('tab', {name: /input/i}).click();
+
+        // solve flowsheet
+        cy.solve_flowsheet()
+
+        // check no flag after solving again
+        cy.get('#inputChangeFlag').should('not.exist');
+        cy.screenshot("re-solved-after-input-change-no-flag "+flowsheet_name)
+    })
+
 })

--- a/electron/ui/cypress/e2e/FlowsheetTesting.cy.js
+++ b/electron/ui/cypress/e2e/FlowsheetTesting.cy.js
@@ -1,177 +1,177 @@
 import { flowsheets } from "./Flowsheets"
 describe('WaterTAP UI Testing', () => {
-    it('tests flowsheets-list page', () => {
-        cy.load_flowsheets_list()
-        cy.screenshot('loaded flowsheet list page')
+    // it('tests flowsheets-list page', () => {
+    //     cy.load_flowsheets_list()
+    //     cy.screenshot('loaded flowsheet list page')
 
-        // verify that heading and table headers are present
-        cy.findByRole('heading', {  name: /flowsheets/i})
-        cy.findByRole('columnheader', {  name: /flowsheet name/i})
-        cy.findByRole('columnheader', {  name: /last run/i})
-        cy.screenshot('end-list-page-test')  
-    })
+    //     // verify that heading and table headers are present
+    //     cy.findByRole('heading', {  name: /flowsheets/i})
+    //     cy.findByRole('columnheader', {  name: /flowsheet name/i})
+    //     cy.findByRole('columnheader', {  name: /last run/i})
+    //     cy.screenshot('end-list-page-test')  
+    // })
 
-    it('tests invalid inputs', () => {
-        cy.load_flowsheets_list()
-        cy.screenshot('loaded flowsheet list page')
+    // it('tests invalid inputs', () => {
+    //     cy.load_flowsheets_list()
+    //     cy.screenshot('loaded flowsheet list page')
         
-        // load flowsheet
-        cy.load_flowsheet("RO with energy recovery flowsheet")
-        cy.screenshot('loaded RO flowsheet');
+    //     // load flowsheet
+    //     cy.load_flowsheet("RO with energy recovery flowsheet")
+    //     cy.screenshot('loaded RO flowsheet');
 
-        // set invalid text input. do it twice to ensure it registers in slow windows runner
-        cy.set_ro_flowrate('dfas');
-        cy.wait(1000)
-        cy.set_ro_flowrate('dfas');
-        cy.wait(1000)
-        cy.screenshot('invalid-text-input');
+    //     // set invalid text input. do it twice to ensure it registers in slow windows runner
+    //     cy.set_ro_flowrate('dfas');
+    //     cy.wait(1000)
+    //     cy.set_ro_flowrate('dfas');
+    //     cy.wait(1000)
+    //     cy.screenshot('invalid-text-input');
 
-        // solve flowsheet
-        cy.solve_flowsheet()
+    //     // solve flowsheet
+    //     cy.solve_flowsheet()
 
-        // verify that error message is there
-        cy.screenshot('error-message');
-        cy.get('.error-message').should('be.visible')
+    //     // verify that error message is there
+    //     cy.screenshot('error-message');
+    //     cy.get('.error-message').should('be.visible')
 
-        // reset flowsheet
-        cy.reset_flowsheet()
-        cy.screenshot('end-invalid-input-test');
-    })
+    //     // reset flowsheet
+    //     cy.reset_flowsheet()
+    //     cy.screenshot('end-invalid-input-test');
+    // })
 
-    it('tests logging panel', () => {
-        cy.load_flowsheets_list()
-        cy.wait(2000)
-        cy.screenshot('loaded flowsheet list page')
+    // it('tests logging panel', () => {
+    //     cy.load_flowsheets_list()
+    //     cy.wait(2000)
+    //     cy.screenshot('loaded flowsheet list page')
         
-        // open logging panel
-        cy.open_logging_panel()
-        cy.screenshot('opened_logs')
+    //     // open logging panel
+    //     cy.open_logging_panel()
+    //     cy.screenshot('opened_logs')
 
-        // verify that a log line of type info and warning are present
-        cy.get('.log-line').contains('INFO')
-        cy.get('.log-line').contains('WARNING')
-        cy.screenshot('end-logging-test')
-    })
+    //     // verify that a log line of type info and warning are present
+    //     cy.get('.log-line').contains('INFO')
+    //     cy.get('.log-line').contains('WARNING')
+    //     cy.screenshot('end-logging-test')
+    // })
 
-    it('tests new flowsheet', () => {
-        let modelFile = "https://drive.google.com/uc?export=download&id=1XdjuWNpYT9teZxaF8TuwDz0XS2XyXKeT"
-        let exportFile = "https://drive.google.com/uc?export=download&id=1-jWQmI4wO2OlyUi32fqobFEmPn3zm9Q9"
-        cy.load_flowsheets_list()
-        cy.screenshot('loaded flowsheet list page')
+    // it('tests new flowsheet', () => {
+    //     let modelFile = "https://drive.google.com/uc?export=download&id=1XdjuWNpYT9teZxaF8TuwDz0XS2XyXKeT"
+    //     let exportFile = "https://drive.google.com/uc?export=download&id=1-jWQmI4wO2OlyUi32fqobFEmPn3zm9Q9"
+    //     cy.load_flowsheets_list()
+    //     cy.screenshot('loaded flowsheet list page')
 
-        // download model and export files
-        cy.downloadFile(modelFile,'cypress/downloads','testModelFile.py')
-        cy.downloadFile(exportFile,'cypress/downloads','testModelFile_ui.py')
+    //     // download model and export files
+    //     cy.downloadFile(modelFile,'cypress/downloads','testModelFile.py')
+    //     cy.downloadFile(exportFile,'cypress/downloads','testModelFile_ui.py')
         
-        // click new flowsheet button
-        cy.findByRole('button', {name: /new flowsheet +/i}).click()
-        cy.wait(500)
-        cy.screenshot("clicked new flowsheet")
+    //     // click new flowsheet button
+    //     cy.findByRole('button', {name: /new flowsheet +/i}).click()
+    //     cy.wait(500)
+    //     cy.screenshot("clicked new flowsheet")
         
-        // select both files
-        cy.get('.ModelFile').selectFile('./cypress/downloads/testModelFile.py', {
-            action: 'drag-drop',
-            force: true
-        })
-        cy.get('.ExportFile').selectFile('./cypress/downloads/testModelFile_ui.py', {
-            action: 'drag-drop',
-            force: true
-        })
-        cy.wait(500)
-        cy.screenshot("dragged and dropped files")
+    //     // select both files
+    //     cy.get('.ModelFile').selectFile('./cypress/downloads/testModelFile.py', {
+    //         action: 'drag-drop',
+    //         force: true
+    //     })
+    //     cy.get('.ExportFile').selectFile('./cypress/downloads/testModelFile_ui.py', {
+    //         action: 'drag-drop',
+    //         force: true
+    //     })
+    //     cy.wait(500)
+    //     cy.screenshot("dragged and dropped files")
 
-        // click upload
-        cy.get('.upload-flowsheet-button').click()
-        cy.wait(1000)
-        cy.screenshot("uploaded files")
+    //     // click upload
+    //     cy.get('.upload-flowsheet-button').click()
+    //     cy.wait(1000)
+    //     cy.screenshot("uploaded files")
 
-        // verify that flowsheet is now in list
-        cy.get('.flowsheet-name').contains(/test custom flowsheet/i)
-        cy.screenshot('end-new-flowsheet-test')
+    //     // verify that flowsheet is now in list
+    //     cy.get('.flowsheet-name').contains(/test custom flowsheet/i)
+    //     cy.screenshot('end-new-flowsheet-test')
 
-    })
+    // })
 
-    flowsheets.forEach((flowsheet) => {
-        it('tests optimization for '+flowsheet.name, () => {
-            cy.load_flowsheets_list()
-            cy.wait(2000)
-            cy.screenshot('loaded flowsheet list page')
+    // flowsheets.forEach((flowsheet) => {
+    //     it('tests optimization for '+flowsheet.name, () => {
+    //         cy.load_flowsheets_list()
+    //         cy.wait(2000)
+    //         cy.screenshot('loaded flowsheet list page')
             
-            // load flowsheet
-            cy.load_flowsheet(flowsheet.name)
-            cy.screenshot('loaded '+flowsheet.name);
+    //         // load flowsheet
+    //         cy.load_flowsheet(flowsheet.name)
+    //         cy.screenshot('loaded '+flowsheet.name);
             
-            // if model has build options, it must be manually built
-            if (flowsheet.buildRequired) {
-                cy.build_flowsheet()
-                cy.screenshot("built "+flowsheet.name)
-            }
+    //         // if model has build options, it must be manually built
+    //         if (flowsheet.buildRequired) {
+    //             cy.build_flowsheet()
+    //             cy.screenshot("built "+flowsheet.name)
+    //         }
 
-            // solve flowsheet
-            cy.solve_flowsheet()
-            cy.screenshot("solved "+flowsheet.name)
+    //         // solve flowsheet
+    //         cy.solve_flowsheet()
+    //         cy.screenshot("solved "+flowsheet.name)
     
-            // Click save configuration button
-            cy.findByRole('button', {name: /save configuration/i}).click()
-            cy.wait(1000)
-            cy.screenshot('pre saveConfig for '+flowsheet.name)
+    //         // Click save configuration button
+    //         cy.findByRole('button', {name: /save configuration/i}).click()
+    //         cy.wait(1000)
+    //         cy.screenshot('pre saveConfig for '+flowsheet.name)
             
-            // Clear preset name and enter new name
-            cy.wait(1000)
-            cy.get('.MuiInput-input').should('be.visible')
-            cy.get('.MuiInput-input', {timeout: 10000}).clear({force: true})
-            cy.get('.MuiInput-input', {timeout: 10000}).type('new_test_configuration', {force: true})
-            cy.screenshot('saveConfig')
+    //         // Clear preset name and enter new name
+    //         cy.wait(1000)
+    //         cy.get('.MuiInput-input').should('be.visible')
+    //         cy.get('.MuiInput-input', {timeout: 10000}).clear({force: true})
+    //         cy.get('.MuiInput-input', {timeout: 10000}).type('new_test_configuration', {force: true})
+    //         cy.screenshot('saveConfig')
     
-            // Click on save (config) and wait for api response
-            cy.save_configuration()
-            cy.screenshot('saved config for '+flowsheet.name)
+    //         // Click on save (config) and wait for api response
+    //         cy.save_configuration()
+    //         cy.screenshot('saved config for '+flowsheet.name)
     
-            // Click compare tab
-            cy.findByRole('tab', {name: /compare/i}).click()
-            cy.wait(5000)
+    //         // Click compare tab
+    //         cy.findByRole('tab', {name: /compare/i}).click()
+    //         cy.wait(5000)
     
-            // Verify that new name is shown in comparison table
-            cy.findAllByRole('tabpanel', {name: /compare/i})
-            cy.screenshot('end-solve-'+flowsheet.name)
-        })
-    })
+    //         // Verify that new name is shown in comparison table
+    //         cy.findAllByRole('tabpanel', {name: /compare/i})
+    //         cy.screenshot('end-solve-'+flowsheet.name)
+    //     })
+    // })
 
-    flowsheets.forEach((flowsheet) => {
-        it('tests parameter sweep '+flowsheet.name, () => {
-            cy.load_flowsheets_list()
-            cy.screenshot('loaded flowsheet list page')
+    // flowsheets.forEach((flowsheet) => {
+    //     it('tests parameter sweep '+flowsheet.name, () => {
+    //         cy.load_flowsheets_list()
+    //         cy.screenshot('loaded flowsheet list page')
             
-            // load flowsheet
-            cy.load_flowsheet(flowsheet.name)
-            cy.screenshot('loaded '+flowsheet.name)
+    //         // load flowsheet
+    //         cy.load_flowsheet(flowsheet.name)
+    //         cy.screenshot('loaded '+flowsheet.name)
 
-            // set solve type to sweep
-            cy.get('#solve-sweep-select').click()
-            cy.wait(100)
-            cy.get('#sweep-option').click()
-            cy.wait(1000)
+    //         // set solve type to sweep
+    //         cy.get('#solve-sweep-select').click()
+    //         cy.wait(100)
+    //         cy.get('#sweep-option').click()
+    //         cy.wait(1000)
 
-            // set sweep variable
-            cy.get('.'+flowsheet.sweepVariable+'_fixed-free-select').click()
-            cy.wait(100)
-            cy.findByRole('option', { name: /sweep/i }).click()
-            cy.wait(100)
+    //         // set sweep variable
+    //         cy.get('.'+flowsheet.sweepVariable+'_fixed-free-select').click()
+    //         cy.wait(100)
+    //         cy.findByRole('option', { name: /sweep/i }).click()
+    //         cy.wait(100)
 
-            // enter lower and upper bounds
-            cy.enter_text('class', flowsheet.sweepVariable+'_lower_input', flowsheet.sweepValues[0])
-            cy.enter_text('class', flowsheet.sweepVariable+'_upper_input', flowsheet.sweepValues[1])
+    //         // enter lower and upper bounds
+    //         cy.enter_text('class', flowsheet.sweepVariable+'_lower_input', flowsheet.sweepValues[0])
+    //         cy.enter_text('class', flowsheet.sweepVariable+'_upper_input', flowsheet.sweepValues[1])
 
-            // run sweep
-            cy.solve_flowsheet()
-            cy.wait(5000)
-            cy.screenshot('ran parameter sweep '+flowsheet.name)
+    //         // run sweep
+    //         cy.solve_flowsheet()
+    //         cy.wait(5000)
+    //         cy.screenshot('ran parameter sweep '+flowsheet.name)
 
-            // verify that sweep was successful
-            cy.get('.parameter-sweep-output-table').should('be.visible')
+    //         // verify that sweep was successful
+    //         cy.get('.parameter-sweep-output-table').should('be.visible')
 
-        })
-    })
+    //     })
+    // })
 
     // RO is most kikely the most canonical 
     // Exclusively run on 'RO with energy recovery flowsheet'
@@ -226,48 +226,55 @@ describe('WaterTAP UI Testing', () => {
         cy.screenshot("value: re-solved-after-input-change-no-flag "+flowsheet_name)
     })
 
-    // it('input change flag for RO with energy recovery value change- fixed/free change', () => {
-    //     cy.load_flowsheets_list()
-    //     cy.screenshot('fixed/free: loaded flowsheet list page')
+    it('input change flag for RO with energy recovery value change- fixed/free change', () => {
+        cy.load_flowsheets_list()
+        cy.screenshot('fixed/free: loaded flowsheet list page')
         
-    //     const flowsheet_name = 'RO with energy recovery flowsheet'
+        const flowsheet_name = 'RO with energy recovery flowsheet'
         
-    //     const flowsheet = flowsheets.find(flowsheet => flowsheet.name === flowsheet_name);
+        const flowsheet = flowsheets.find(flowsheet => flowsheet.name === flowsheet_name);
         
-    //     // load flowsheet
-    //     cy.load_flowsheet(flowsheet.name)
-    //     cy.screenshot('fixed/free: loaded '+flowsheet.name)
+        // load flowsheet
+        cy.load_flowsheet(flowsheet.name)
+        cy.screenshot('fixed/free: loaded '+flowsheet.name)
 
-    //     // solve flowsheet
-    //     cy.solve_flowsheet()
-    //     cy.screenshot("fixed/free: solved "+flowsheet.name)
-
-
-    //     cy.findByRole('tab', {name: /output/i}).click();
-
-    //     // check no flag
-    //     cy.get('#inputChangeFlag').should('not.exist');
-    //     cy.screenshot('fixed/free: no-input-change-no-flag-'+flowsheet.name)
-
-    //     cy.findByRole('tab', {name: /input/i}).click();
+        // solve flowsheet
+        cy.solve_flowsheet()
+        cy.screenshot("fixed/free: solved "+flowsheet.name)
 
 
-    //     // set free variable
-    //     cy.get('.'+flowsheet.sweepVariable+'_fixed-free-select').click()
-    //     cy.wait(100)
-    //     cy.findByRole('option', { name: /free/i }).click()
-    //     cy.wait(100)
-    //     cy.screenshot('fixed/free: change-option-free '+flowsheet.name)
+        cy.findByRole('tab', {name: /output/i}).click();
 
-    //     // go to outputs
-    //     cy.findByRole('tab', {name: /output/i}).click()
-    //     cy.screenshot('fixed/free: LOOK' + flowsheet.name);
+        // check no flag
+        cy.get('#inputChangeFlag').should('not.exist');
+        cy.screenshot('fixed/free: no-input-change-no-flag-'+flowsheet.name)
 
-    //     // // check for flag 
-    //     // cy.get('#inputChangeFlag').should('exist');
-    //     // cy.screenshot('fixed/free: output-flag-after-input-change-flag ' + flowsheet.name);
+        cy.findByRole('tab', {name: /input/i}).click();
 
-    // })
+
+        // set free variable
+        cy.get('.'+flowsheet.sweepVariable+'_fixed-free-select').click()
+        cy.wait(100)
+        cy.findByRole('option', { name: /free/i }).click()
+        cy.get('.'+flowsheet.sweepVariable+'_fixed-free-select').click()
+        cy.wait(100)
+
+        cy.findByRole('option', { name: /fixed/i }).click()
+
+        cy.wait(100)
+        cy.screenshot('fixed/free: change-option-free '+flowsheet.name)
+
+        // go to outputs
+        cy.findByRole('tab', {name: /output/i}).click()
+        cy.screenshot('fixed/free: LOOK' + flowsheet.name);
+
+        cy.wait(500)
+
+        // // check for flag 
+        cy.get('#inputChangeFlag').should('exist');
+        cy.screenshot('fixed/free: output-flag-after-input-change-flag ' + flowsheet.name);
+
+    })
 
     it('input change flag for RO with energy recovery value change- bounds change', () => {
         cy.load_flowsheets_list()

--- a/electron/ui/cypress/support/commands.js
+++ b/electron/ui/cypress/support/commands.js
@@ -134,7 +134,5 @@ Cypress.Commands.add('enter_text', (identifier, role_or_class, value, name ) => 
         input_textbox.type('{backspace}{backspace}{backspace}{backspace}' + value);
 
     }
-    // input_textbox.clear().type(value)
-    // input_textbox.type('{backspace}{backspace}{backspace}{backspace}' + value);
     cy.wait(500);
 })

--- a/electron/ui/cypress/support/commands.js
+++ b/electron/ui/cypress/support/commands.js
@@ -126,16 +126,15 @@ Cypress.Commands.add('enter_text', (identifier, role_or_class, value, name ) => 
     input_textbox.click({force:true});
     if (identifier === "role") {
         input_textbox = cy.findByRole(role_or_class, {name: name});
-        // input_textbox.clear().type(value)
+        input_textbox.clear().type(value)
 
     }
     else if (identifier === "class") {
         input_textbox = cy.get('.'+role_or_class);
-        // input_textbox.type('{backspace}{backspace}{backspace}{backspace}' + value);
+        input_textbox.type('{backspace}{backspace}{backspace}{backspace}' + value);
 
     }
-    input_textbox.clear().type(value)
-
+    // input_textbox.clear().type(value)
     // input_textbox.type('{backspace}{backspace}{backspace}{backspace}' + value);
     cy.wait(500);
 })

--- a/electron/ui/cypress/support/commands.js
+++ b/electron/ui/cypress/support/commands.js
@@ -126,10 +126,16 @@ Cypress.Commands.add('enter_text', (identifier, role_or_class, value, name ) => 
     input_textbox.click({force:true});
     if (identifier === "role") {
         input_textbox = cy.findByRole(role_or_class, {name: name});
+        // input_textbox.clear().type(value)
+
     }
     else if (identifier === "class") {
         input_textbox = cy.get('.'+role_or_class);
+        // input_textbox.type('{backspace}{backspace}{backspace}{backspace}' + value);
+
     }
-    input_textbox.type('{backspace}{backspace}{backspace}{backspace}' + value);
+    input_textbox.clear().type(value)
+
+    // input_textbox.type('{backspace}{backspace}{backspace}{backspace}' + value);
     cy.wait(500);
 })

--- a/electron/ui/src/views/FlowsheetConfig/ConfigInput/ConfigInput.js
+++ b/electron/ui/src/views/FlowsheetConfig/ConfigInput/ConfigInput.js
@@ -68,12 +68,6 @@ export default function ConfigInput(props) {
             })
     }, [flowsheetData.inputData]);
 
-    // this is bad
-    useEffect(() => {
-        setInputsChanged(true)
-    }, [displayData])
-
-
     useEffect(() => {
         // console.log(`setting number of subprocesses current: ${numberOfSubprocesses.current}, max: ${numberOfSubprocesses.max}`)
         setCurrentNumberOfSubprocesses(numberOfSubprocesses.current)
@@ -152,9 +146,26 @@ export default function ConfigInput(props) {
     const handleUpdateDisplayValue = (id, value) => {
         let tempFlowsheetData = { ...flowsheetData };
         const inputs = getInputs(tempFlowsheetData)
+
         console.debug('updating ' + id + ' with value ' + value + '. previous value was ' + inputs[id].value)
         inputs[id].value = value
+
+        // if (outputs!= null || value != Number(outputs.exports[id].value).toFixed(outputs.exports[id].rounding)) {
+            setInputsChanged(true)
+            //   }
+        //      else {
+        //     setInputsChanged(false)
+
+        //         // setAlteredInputs(alteredInputs().filter((_,i) => i !== id))
+        //     // setAlteredInputs(altertedInputs)
+        // }
+
 }
+
+// solved, solved and changed, only changed
+// solved ->
+// solved and changed,
+//  only changed
 
     const handleUpdateFixed = (id, value, type) => {
         let tempFlowsheetData = {...flowsheetData}
@@ -162,6 +173,7 @@ export default function ConfigInput(props) {
         inputs[id].fixed = value;
         inputs[id].is_sweep = (type === "sweep");
         updateFlowsheetData(tempFlowsheetData, null)
+        setInputsChanged(true)
         runButtonRef.current?.checkDisableRun()
         // checkDisableRun()
     }
@@ -169,6 +181,7 @@ export default function ConfigInput(props) {
     const handleUpdateBounds = (id, value, bound) => {
         let tempFlowsheetData = {...flowsheetData}
         const inputs = getInputs(tempFlowsheetData)
+        setInputsChanged(true)
         inputs[id][bound] = value
     }
 
@@ -176,6 +189,7 @@ export default function ConfigInput(props) {
         let tempFlowsheetData = {...flowsheetData}
         const inputs = getInputs(tempFlowsheetData)
         inputs[id].num_samples = value
+        setInputsChanged(true)
         console.debug('updating samples ' + id + ' with value ' + value + ' ' + inputs[id].num_samples)
     }
     /**

--- a/electron/ui/src/views/FlowsheetConfig/ConfigInput/ConfigInput.js
+++ b/electron/ui/src/views/FlowsheetConfig/ConfigInput/ConfigInput.js
@@ -145,27 +145,12 @@ export default function ConfigInput(props) {
 
     const handleUpdateDisplayValue = (id, value) => {
         let tempFlowsheetData = { ...flowsheetData };
-        const inputs = getInputs(tempFlowsheetData)
+        const inputs = getInputs(tempFlowsheetData);
 
-        console.debug('updating ' + id + ' with value ' + value + '. previous value was ' + inputs[id].value)
-        inputs[id].value = value
-
-        // if (outputs!= null || value != Number(outputs.exports[id].value).toFixed(outputs.exports[id].rounding)) {
-            setInputsChanged(true)
-            //   }
-        //      else {
-        //     setInputsChanged(false)
-
-        //         // setAlteredInputs(alteredInputs().filter((_,i) => i !== id))
-        //     // setAlteredInputs(altertedInputs)
-        // }
-
-}
-
-// solved, solved and changed, only changed
-// solved ->
-// solved and changed,
-//  only changed
+        console.debug('updating ' + id + ' with value ' + value + '. previous value was ' + inputs[id].value);
+        inputs[id].value = value;
+        setInputsChanged(true);
+    };
 
     const handleUpdateFixed = (id, value, type) => {
         let tempFlowsheetData = {...flowsheetData}
@@ -266,7 +251,14 @@ export default function ConfigInput(props) {
             if (Object.keys(displayData).length > 0) {
                 let var_sections = organizeVariables(displayData.exports)
                 return Object.entries(var_sections).map(([key, value]) => {
-                    let _key = key + Math.floor(Math.random() * 100001);
+                    let _key;
+                    if (key === undefined || key === null) {
+                        _key = key + Math.floor(Math.random() * 100001);
+                    } else {
+                        _key = key + value.display_name + value.output_variables;
+                    }
+                    console.log(_key);
+
                     if (Object.keys(value.input_variables).length > 0) {
                         return (<Grid item xs={6} key={_key}>
                             <InputAccordion

--- a/electron/ui/src/views/FlowsheetConfig/ConfigInput/ConfigInput.js
+++ b/electron/ui/src/views/FlowsheetConfig/ConfigInput/ConfigInput.js
@@ -22,7 +22,8 @@ export default function ConfigInput(props) {
         reset,
         solveType,
         numberOfSubprocesses,
-        setNumberOfSubprocesses
+        setNumberOfSubprocesses,
+        setInputsChanged
     } = props;
     const [displayData, setDisplayData] = useState({})
     const [previousConfigs, setPreviousConfigs] = useState([])
@@ -66,6 +67,12 @@ export default function ConfigInput(props) {
                 }
             })
     }, [flowsheetData.inputData]);
+
+    // this is bad
+    useEffect(() => {
+        setInputsChanged(true)
+    }, [displayData])
+
 
     useEffect(() => {
         // console.log(`setting number of subprocesses current: ${numberOfSubprocesses.current}, max: ${numberOfSubprocesses.max}`)
@@ -143,11 +150,11 @@ export default function ConfigInput(props) {
     }
 
     const handleUpdateDisplayValue = (id, value) => {
-        let tempFlowsheetData = {...flowsheetData}
+        let tempFlowsheetData = { ...flowsheetData };
         const inputs = getInputs(tempFlowsheetData)
         console.debug('updating ' + id + ' with value ' + value + '. previous value was ' + inputs[id].value)
         inputs[id].value = value
-    }
+}
 
     const handleUpdateFixed = (id, value, type) => {
         let tempFlowsheetData = {...flowsheetData}
@@ -349,7 +356,7 @@ export default function ConfigInput(props) {
                                 flowsheetData={flowsheetData}
                                 disableRun={disableRun}
                                 solveType={solveType}
-                                ref={runButtonRef}
+                                ref={runButtonRef}                           
                             />
                         </Stack>
                     </Grid>

--- a/electron/ui/src/views/FlowsheetConfig/ConfigInput/ConfigInput.js
+++ b/electron/ui/src/views/FlowsheetConfig/ConfigInput/ConfigInput.js
@@ -144,13 +144,12 @@ export default function ConfigInput(props) {
     }
 
     const handleUpdateDisplayValue = (id, value) => {
-        let tempFlowsheetData = { ...flowsheetData };
-        const inputs = getInputs(tempFlowsheetData);
-
-        console.debug('updating ' + id + ' with value ' + value + '. previous value was ' + inputs[id].value);
-        inputs[id].value = value;
-        setInputsChanged(true);
-    };
+        let tempFlowsheetData = {...flowsheetData}
+        const inputs = getInputs(tempFlowsheetData)
+        console.debug('updating ' + id + ' with value ' + value + '. previous value was ' + inputs[id].value)
+        inputs[id].value = value
+        setInputsChanged(true)
+    }
 
     const handleUpdateFixed = (id, value, type) => {
         let tempFlowsheetData = {...flowsheetData}
@@ -255,9 +254,8 @@ export default function ConfigInput(props) {
                     if (key === undefined || key === null) {
                         _key = key + Math.floor(Math.random() * 100001);
                     } else {
-                        _key = key + value.display_name + value.output_variables;
+                    _key = key + value.display_name + value.output_variables;
                     }
-
                     if (Object.keys(value.input_variables).length > 0) {
                         return (<Grid item xs={6} key={_key}>
                             <InputAccordion
@@ -361,7 +359,7 @@ export default function ConfigInput(props) {
                                 flowsheetData={flowsheetData}
                                 disableRun={disableRun}
                                 solveType={solveType}
-                                ref={runButtonRef}                           
+                                ref={runButtonRef}
                             />
                         </Stack>
                     </Grid>

--- a/electron/ui/src/views/FlowsheetConfig/ConfigInput/ConfigInput.js
+++ b/electron/ui/src/views/FlowsheetConfig/ConfigInput/ConfigInput.js
@@ -257,7 +257,6 @@ export default function ConfigInput(props) {
                     } else {
                         _key = key + value.display_name + value.output_variables;
                     }
-                    console.log(_key);
 
                     if (Object.keys(value.input_variables).length > 0) {
                         return (<Grid item xs={6} key={_key}>

--- a/electron/ui/src/views/FlowsheetConfig/ConfigOutput/ConfigOutput.js
+++ b/electron/ui/src/views/FlowsheetConfig/ConfigOutput/ConfigOutput.js
@@ -35,12 +35,9 @@ export default function ConfigOutput(props) {
         <Box>
              {inputsChanged ? 
             <Alert  color = "warning" severity = 'warning' >
-            Inputs changed since last run
+            Inputs changed since last Run
 
-        </Alert> :
-            <Alert color = 'success' severity='success'>
-                success!
-            </Alert>}
+        </Alert> : <></>}
             <Grid container spacing={2} alignItems="flex-start">
                 {isSweep ?
                     <SweepOutput outputData={outputData}

--- a/electron/ui/src/views/FlowsheetConfig/ConfigOutput/ConfigOutput.js
+++ b/electron/ui/src/views/FlowsheetConfig/ConfigOutput/ConfigOutput.js
@@ -12,9 +12,9 @@ import SingleOutput from "../../../components/SingleOutput/SingleOutput";
 
 
 export default function ConfigOutput(props) {
-    let params = useParams();    
+    let params = useParams();
     const {outputData, isSweep, inputsChanged} = props;
-    
+
     // Use a temporary hyperlink to download sweep output
     const downloadSweepOutput = () => {
         downloadSweepResults(params.id)
@@ -33,22 +33,20 @@ export default function ConfigOutput(props) {
     // Return either sweep or single-output version
     return (
         <Box>
-             {inputsChanged ? 
-            <Alert  color = "warning" severity = 'warning' >
-            Inputs changed since last Run
-
-        </Alert> : <></>}
+            {inputsChanged ?
+                <Alert color="warning" severity='warning' >
+                    Inputs changed since last run
+                </Alert> : <></>}
             <Grid container spacing={2} alignItems="flex-start">
                 {isSweep ?
                     <SweepOutput outputData={outputData}
-                                downloadOutput={downloadSweepOutput}/>
+                        downloadOutput={downloadSweepOutput} />
                     :
                     <SingleOutput outputData={outputData}
-                                downloadOutput={downloadSingleOutput}
-                                saveConfig={saveConfig}/>
+                        downloadOutput={downloadSingleOutput}
+                        saveConfig={saveConfig} />
                 }
             </Grid>
         </Box>
     );
 }
-

--- a/electron/ui/src/views/FlowsheetConfig/ConfigOutput/ConfigOutput.js
+++ b/electron/ui/src/views/FlowsheetConfig/ConfigOutput/ConfigOutput.js
@@ -34,7 +34,7 @@ export default function ConfigOutput(props) {
     return (
         <Box>
             {inputsChanged ?
-                <Alert color="warning" severity='warning' >
+                <Alert id = 'inputChangeFlag' color="warning" severity='warning' >
                     Inputs changed since last run
                 </Alert> : <></>}
             <Grid container spacing={2} alignItems="flex-start">

--- a/electron/ui/src/views/FlowsheetConfig/ConfigOutput/ConfigOutput.js
+++ b/electron/ui/src/views/FlowsheetConfig/ConfigOutput/ConfigOutput.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useParams} from "react-router-dom";
-import Grid from '@mui/material/Grid';
+import { Grid, Box, Alert } from '@mui/material';
 import {
     downloadSweepResults,
     downloadSingleOutput,
@@ -12,9 +12,9 @@ import SingleOutput from "../../../components/SingleOutput/SingleOutput";
 
 
 export default function ConfigOutput(props) {
-    let params = useParams();
+    let params = useParams();    
     const {outputData, isSweep} = props;
-
+    
     // Use a temporary hyperlink to download sweep output
     const downloadSweepOutput = () => {
         downloadSweepResults(params.id)
@@ -32,16 +32,26 @@ export default function ConfigOutput(props) {
 
     // Return either sweep or single-output version
     return (
-        <Grid container spacing={2} alignItems="flex-start">
-            {isSweep ?
-                <SweepOutput outputData={outputData}
-                             downloadOutput={downloadSweepOutput}/>
-                :
-                <SingleOutput outputData={outputData}
-                              downloadOutput={downloadSingleOutput}
-                              saveConfig={saveConfig}/>
-            }
-        </Grid>
+        <Box>
+             {inputsChanged ? 
+            <Alert  color = "warning" severity = 'warning' >
+            Inputs changed since last run
+
+        </Alert> :
+            <Alert color = 'success' severity='success'>
+                success!
+            </Alert>}
+            <Grid container spacing={2} alignItems="flex-start">
+                {isSweep ?
+                    <SweepOutput outputData={outputData}
+                                downloadOutput={downloadSweepOutput}/>
+                    :
+                    <SingleOutput outputData={outputData}
+                                downloadOutput={downloadSingleOutput}
+                                saveConfig={saveConfig}/>
+                }
+            </Grid>
+        </Box>
     );
 }
- 
+

--- a/electron/ui/src/views/FlowsheetConfig/ConfigOutput/ConfigOutput.js
+++ b/electron/ui/src/views/FlowsheetConfig/ConfigOutput/ConfigOutput.js
@@ -13,7 +13,7 @@ import SingleOutput from "../../../components/SingleOutput/SingleOutput";
 
 export default function ConfigOutput(props) {
     let params = useParams();    
-    const {outputData, isSweep} = props;
+    const {outputData, isSweep, inputsChanged} = props;
     
     // Use a temporary hyperlink to download sweep output
     const downloadSweepOutput = () => {

--- a/electron/ui/src/views/FlowsheetConfig/ConfigOutput/ConfigOutput.js
+++ b/electron/ui/src/views/FlowsheetConfig/ConfigOutput/ConfigOutput.js
@@ -34,7 +34,7 @@ export default function ConfigOutput(props) {
     return (
         <Box>
             {inputsChanged ?
-                <Alert id = 'inputChangeFlag' color="warning" severity='warning' >
+                <Alert id = 'inputChangeFlag' color="warning" severity='warning' sx={{ mb: '2rem' }}>
                     Inputs changed since last run
                 </Alert> : <></>}
             <Grid container spacing={2} alignItems="flex-start">

--- a/electron/ui/src/views/FlowsheetConfig/FlowsheetConfig.js
+++ b/electron/ui/src/views/FlowsheetConfig/FlowsheetConfig.js
@@ -91,6 +91,8 @@ export default function FlowsheetConfig(props) {
 
 
     const [inputsChanged, setInputsChanged] = useState(false);
+    // const [alteredInputs, setAlteredInputs] = useState([])
+
     // const [dialogVisible, setDialogVisible] = useState(false);
     // const [pendingPath, setPendingPath] = useState(null);
 
@@ -219,6 +221,7 @@ export default function FlowsheetConfig(props) {
         setFlowsheetData(tempFlowsheetData);
         setTabValue(1);
         setSolveDialogOpen(false);
+        setInputsChanged(false)
     }
 
     const handleError = (msg) => {
@@ -307,6 +310,13 @@ export default function FlowsheetConfig(props) {
             return option
         }
     }
+
+    // useEffect(()=>{
+    //     if(alteredInputs.length >= 1) {
+    //         setInputsChanged(true)
+    //     }
+
+    // }, [alteredInputs])
 
     console.log("Returning container for FlowsheetConfig. build_options=", flowsheetData.inputData.build_options, "isBuilt=", isBuilt,
         "loadingFlowsheetData=", loadingFlowsheetData);

--- a/electron/ui/src/views/FlowsheetConfig/FlowsheetConfig.js
+++ b/electron/ui/src/views/FlowsheetConfig/FlowsheetConfig.js
@@ -1,13 +1,13 @@
 //import './Page.css';
 import React from 'react';
-import { useEffect, useState } from 'react';
-import { useParams, useNavigate, useLocation } from "react-router-dom";
+import {useEffect, useState} from 'react';
+import {useParams, useNavigate, useLocation} from "react-router-dom";
 import {
     getFlowsheet,
     saveFlowsheet,
     resetFlowsheet
 } from "../../services/flowsheet.service";
-import { Dialog, DialogTitle, DialogActions, DialogContent } from '@mui/material'
+import {Dialog, DialogTitle, DialogActions, DialogContent} from '@mui/material'
 import {
     Typography,
     CircularProgress,
@@ -16,7 +16,7 @@ import {
     Box,
     Grid,
     Container,
-    Snackbar,
+    Snackbar
 } from '@mui/material';
 import Graph from "../../components/Graph/Graph";
 import ConfigInput from "./ConfigInput/ConfigInput";
@@ -89,12 +89,7 @@ export default function FlowsheetConfig(props) {
     const theme = props.theme;
     console.log("flowsheet config theme=", theme);
 
-
     const [inputsChanged, setInputsChanged] = useState(false);
-    // const [alteredInputs, setAlteredInputs] = useState([])
-
-    // const [dialogVisible, setDialogVisible] = useState(false);
-    // const [pendingPath, setPendingPath] = useState(null);
 
     useEffect(() => {
         console.log("params.id", params.id);
@@ -124,9 +119,9 @@ export default function FlowsheetConfig(props) {
                 setFlowsheetData({outputData: null, inputData: data, name: data.name});
                 setTitle(getTitle(data));
             }).catch((e) => {
-                console.error('error getting flowsheet: ', e)
-                navigateHome(e)
-            });
+            console.error('error getting flowsheet: ', e)
+            navigateHome(e)
+        });
     }, [params.id]);
 
     useEffect(() => {
@@ -153,18 +148,19 @@ export default function FlowsheetConfig(props) {
                 setFlowsheetData({outputData: null, inputData: data, name: data.name});
                 setTitle(getTitle(data));
             }).catch((e) => {
-                console.error('error getting flowsheet: ', e)
-                navigateHome(e)
-            });
+            console.error('error getting flowsheet: ', e)
+            navigateHome(e)
+        });
     }
 
     const navigateHome = (e) => {
-        navigate("/flowsheets", { replace: true, state: { error: e } })
+        navigate("/flowsheets", {replace: true, state: {error: e}})
     }
 
     const handleTabChange = (event, newValue) => {
         setTabValue(newValue);
-};
+    };
+
 
     const getTitle = (data) => {
         try {
@@ -236,26 +232,26 @@ export default function FlowsheetConfig(props) {
       saveFlowsheet(params.id, data)
       .then(response => {
         if(response.status === 200) {
-                    response.json()
+          response.json()
           .then((data)=>{
             let tempFlowsheetData = {...flowsheetData}
-                            tempFlowsheetData.inputData = data
-                            if (outputData) {
-                                tempFlowsheetData.outputData = outputData
+            tempFlowsheetData.inputData = data
+            if (outputData) {
+              tempFlowsheetData.outputData = outputData
 
-                            }
-                            if (update) {
-                                console.log("SETTING FLOWSHEET DATA")
-                                setFlowsheetData(tempFlowsheetData)
-                            }
-                        });
+            }
+            if (update) {
+              console.log("SETTING FLOWSHEET DATA")
+              setFlowsheetData(tempFlowsheetData)
+            }
+          });
         } else if(response.status === 400) {
-                    console.error("error saving data")
-                    handleError("Infeasible data, configuration not saved")
-                }
-
-            })
-
+          console.error("error saving data")
+          handleError("Infeasible data, configuration not saved")
+        }
+        
+      })
+        
     };
 
     const handleSuccessSaveConfirmationClose = () => {
@@ -276,9 +272,9 @@ export default function FlowsheetConfig(props) {
                 setFlowsheetData({outputData: null, inputData: data, name: data.name});
                 setTitle(getTitle(data));
             }).catch((e) => {
-                console.error('error getting flowsheet: ', e)
-                navigateHome(e)
-            });
+            console.error('error getting flowsheet: ', e)
+            navigateHome(e)
+        });
     }
 
     const handleSelectSolveType = (event) => {
@@ -296,12 +292,12 @@ export default function FlowsheetConfig(props) {
 
     const handleSaveConfiguration = () => {
         if (analysisName.length > 0) {
-            
+
         } else {
             setOpenErrorMessage(true)
             setErrorMessage("Please provide a name for analysis.")
         }
-}
+    }
 
     const formatOptionType = (option) => {
         try {
@@ -310,13 +306,6 @@ export default function FlowsheetConfig(props) {
             return option
         }
     }
-
-    // useEffect(()=>{
-    //     if(alteredInputs.length >= 1) {
-    //         setInputsChanged(true)
-    //     }
-
-    // }, [alteredInputs])
 
     console.log("Returning container for FlowsheetConfig. build_options=", flowsheetData.inputData.build_options, "isBuilt=", isBuilt,
         "loadingFlowsheetData=", loadingFlowsheetData);
@@ -434,7 +423,7 @@ export default function FlowsheetConfig(props) {
                                                       isSweep={sweep}
                                                       solveType={solveType}
                                                       inputsChanged={inputsChanged}
-                                                      >
+                                        >
                                         </ConfigOutput>
                                     </TabPanel>
                                     <TabPanel value={tabValue} index={2}>
@@ -449,8 +438,8 @@ export default function FlowsheetConfig(props) {
                 )
             }
             <SolveDialog open={solveDialogOpen} handleSolved={handleSolved}
-                handleError={handleError} flowsheetData={flowsheetData}
-                id={params.id} isSweep={sweep}></SolveDialog>
+                         handleError={handleError} flowsheetData={flowsheetData}
+                         id={params.id} isSweep={sweep}></SolveDialog>
             <Snackbar
                 open={openSuccessSaveConfirmation}
                 autoHideDuration={2000}

--- a/electron/ui/src/views/FlowsheetConfig/FlowsheetConfig.js
+++ b/electron/ui/src/views/FlowsheetConfig/FlowsheetConfig.js
@@ -1,13 +1,13 @@
 //import './Page.css';
 import React from 'react';
-import {useEffect, useState} from 'react';
-import {useParams, useNavigate, useLocation} from "react-router-dom";
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import {
     getFlowsheet,
     saveFlowsheet,
     resetFlowsheet
 } from "../../services/flowsheet.service";
-import {Dialog, DialogTitle, DialogActions, DialogContent} from '@mui/material'
+import { Dialog, DialogTitle, DialogActions, DialogContent } from '@mui/material'
 import {
     Typography,
     CircularProgress,
@@ -16,7 +16,7 @@ import {
     Box,
     Grid,
     Container,
-    Snackbar
+    Snackbar,
 } from '@mui/material';
 import Graph from "../../components/Graph/Graph";
 import ConfigInput from "./ConfigInput/ConfigInput";
@@ -89,6 +89,11 @@ export default function FlowsheetConfig(props) {
     const theme = props.theme;
     console.log("flowsheet config theme=", theme);
 
+
+    const [inputsChanged, setInputsChanged] = useState(false);
+    // const [dialogVisible, setDialogVisible] = useState(false);
+    // const [pendingPath, setPendingPath] = useState(null);
+
     useEffect(() => {
         console.log("params.id", params.id);
         if (!params.hasOwnProperty("id") || !params.id)
@@ -117,9 +122,9 @@ export default function FlowsheetConfig(props) {
                 setFlowsheetData({outputData: null, inputData: data, name: data.name});
                 setTitle(getTitle(data));
             }).catch((e) => {
-            console.error('error getting flowsheet: ', e)
-            navigateHome(e)
-        });
+                console.error('error getting flowsheet: ', e)
+                navigateHome(e)
+            });
     }, [params.id]);
 
     useEffect(() => {
@@ -146,19 +151,18 @@ export default function FlowsheetConfig(props) {
                 setFlowsheetData({outputData: null, inputData: data, name: data.name});
                 setTitle(getTitle(data));
             }).catch((e) => {
-            console.error('error getting flowsheet: ', e)
-            navigateHome(e)
-        });
+                console.error('error getting flowsheet: ', e)
+                navigateHome(e)
+            });
     }
 
     const navigateHome = (e) => {
-        navigate("/flowsheets", {replace: true, state: {error: e}})
+        navigate("/flowsheets", { replace: true, state: { error: e } })
     }
 
     const handleTabChange = (event, newValue) => {
         setTabValue(newValue);
-    };
-
+};
 
     const getTitle = (data) => {
         try {
@@ -229,26 +233,26 @@ export default function FlowsheetConfig(props) {
       saveFlowsheet(params.id, data)
       .then(response => {
         if(response.status === 200) {
-          response.json()
+                    response.json()
           .then((data)=>{
             let tempFlowsheetData = {...flowsheetData}
-            tempFlowsheetData.inputData = data
-            if (outputData) {
-              tempFlowsheetData.outputData = outputData
+                            tempFlowsheetData.inputData = data
+                            if (outputData) {
+                                tempFlowsheetData.outputData = outputData
 
-            }
-            if (update) {
-              console.log("SETTING FLOWSHEET DATA")
-              setFlowsheetData(tempFlowsheetData)
-            }
-          });
+                            }
+                            if (update) {
+                                console.log("SETTING FLOWSHEET DATA")
+                                setFlowsheetData(tempFlowsheetData)
+                            }
+                        });
         } else if(response.status === 400) {
-          console.error("error saving data")
-          handleError("Infeasible data, configuration not saved")
-        }
-        
-      })
-        
+                    console.error("error saving data")
+                    handleError("Infeasible data, configuration not saved")
+                }
+
+            })
+
     };
 
     const handleSuccessSaveConfirmationClose = () => {
@@ -269,9 +273,9 @@ export default function FlowsheetConfig(props) {
                 setFlowsheetData({outputData: null, inputData: data, name: data.name});
                 setTitle(getTitle(data));
             }).catch((e) => {
-            console.error('error getting flowsheet: ', e)
-            navigateHome(e)
-        });
+                console.error('error getting flowsheet: ', e)
+                navigateHome(e)
+            });
     }
 
     const handleSelectSolveType = (event) => {
@@ -289,12 +293,12 @@ export default function FlowsheetConfig(props) {
 
     const handleSaveConfiguration = () => {
         if (analysisName.length > 0) {
-
+            
         } else {
             setOpenErrorMessage(true)
             setErrorMessage("Please provide a name for analysis.")
         }
-    }
+}
 
     const formatOptionType = (option) => {
         try {
@@ -390,10 +394,10 @@ export default function FlowsheetConfig(props) {
                                                     <Tab
                                                         label="Input" {...a11yProps(0)} />
                                                     <Tab label="Output"
-                                                         disabled={!flowsheetData.outputData} {...a11yProps(1)} />
+                                                        disabled={!flowsheetData.outputData} {...a11yProps(1)} />
                                                     {solveType === "solve" &&
                                                         <Tab label="Compare"
-                                                             disabled={!flowsheetData.outputData} {...a11yProps(2)} />}
+                                                            disabled={!flowsheetData.outputData} {...a11yProps(2)} />}
                                                 </Tabs>
                                             </div>
 
@@ -411,14 +415,16 @@ export default function FlowsheetConfig(props) {
                                             handleSelectSolveType={handleSelectSolveType}
                                             numberOfSubprocesses={props.numberOfSubprocesses}
                                             setNumberOfSubprocesses={props.setNumberOfSubprocesses}
-                                        >
-                                        </ConfigInput>
+                                            setInputsChanged={setInputsChanged}
+                                        />
                                     </TabPanel>
                                     <TabPanel value={tabValue} index={1}>
                                         <ConfigOutput outputData={flowsheetData}
                                                       updateFlowsheetData={updateFlowsheetData}
                                                       isSweep={sweep}
-                                                      solveType={solveType}>
+                                                      solveType={solveType}
+                                                      inputsChanged={inputsChanged}
+                                                      >
                                         </ConfigOutput>
                                     </TabPanel>
                                     <TabPanel value={tabValue} index={2}>
@@ -433,8 +439,8 @@ export default function FlowsheetConfig(props) {
                 )
             }
             <SolveDialog open={solveDialogOpen} handleSolved={handleSolved}
-                         handleError={handleError} flowsheetData={flowsheetData}
-                         id={params.id} isSweep={sweep}></SolveDialog>
+                handleError={handleError} flowsheetData={flowsheetData}
+                id={params.id} isSweep={sweep}></SolveDialog>
             <Snackbar
                 open={openSuccessSaveConfirmation}
                 autoHideDuration={2000}


### PR DESCRIPTION
re: #120 

Users can edit inputs and access the output tag without re-running. The goal is to add an indication "flag" that the outputs are derived from the inputs run, not the inputs currently in the input tab. 

- added boolean field to indicate inputs changed `inputsChanged` in FlowsheetConfig
- inputsChanged is updated when display values are changed in the 'handle' events in ConfigInput
- Alert component is enabled by flag `inputsChanged` when true
- After the running, inputs changed is reset to False in Flowsheet config